### PR TITLE
ENH:  Increase code coverage.

### DIFF
--- a/test/ScalarImageToRunLengthFeaturesImageFilterTest.cxx
+++ b/test/ScalarImageToRunLengthFeaturesImageFilterTest.cxx
@@ -22,49 +22,99 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToRunLengthFeaturesImageFilterTest(int argc, char * argv[])
+int ScalarImageToRunLengthFeaturesImageFilterTest( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::Image< itk::Vector< float, 10 > , 3 >  OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [minDistance]"
+      << " [maxDistance]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 10;
+
+  // Declare types
+  typedef int                                         InputPixelType;
+  typedef float                                       OutputPixelComponentType;
+  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
+                                                      OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                    NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+
+  FilterType::Pointer filter = FilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( filter, ScalarImageToRunLengthFeaturesImageFilter,
+    ImageToImageFilter );
+
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+  TEST_SET_GET_VALUE( maskReader->GetOutput(), filter->GetMaskImage() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+    TEST_SET_GET_VALUE( numberOfBinsPerAxis, filter->GetNumberOfBinsPerAxis() );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    TEST_SET_GET_VALUE( pixelValueMin, filter->GetMin() );
+    TEST_SET_GET_VALUE( pixelValueMax, filter->GetMax() );
+
+    FilterType::RealType minDistance = std::atof( argv[7] );
+    FilterType::RealType maxDistance = std::atof( argv[8] );
+    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+    TEST_SET_GET_VALUE( minDistance, filter->GetMinDistance() );
+    TEST_SET_GET_VALUE( maxDistance, filter->GetMaxDistance() );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    TEST_SET_GET_VALUE( hood.GetRadius(), filter->GetNeighborhoodRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
+  // Create and set up a writer
+  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( argv[3] );
+  writer->SetInput( filter->GetOutput() );
 
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      filter->SetDistanceValueMinMax(std::atof(argv[7]),std::atof(argv[8]));
-      hood.SetRadius( std::atoi(argv[9]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-    // Create and setup a writter
-    typedef  itk::ImageFileWriter< OutputImageType  > WriterType;
-    WriterType::Pointer writer = WriterType::New();
-    std::string outputFilename = argv[3];
-    writer->SetFileName(outputFilename.c_str());
-    writer->SetInput(filter->GetOutput());
-    writer->UpdateLargestPossibleRegion();
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToRunLengthFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/ScalarImageToRunLengthFeaturesImageFilterTestSeparateFeatures.cxx
@@ -23,63 +23,104 @@
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
 #include "itkVectorIndexSelectionCastImageFilter.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToRunLengthFeaturesImageFilterTestSeparateFeatures(int argc, char * argv[])
+int ScalarImageToRunLengthFeaturesImageFilterTestSeparateFeatures( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::Image< itk::Vector< float, 10 > , 3 >  OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [minDistance]"
+      << " [maxDistance]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 10;
+
+  // Declare types
+  typedef int                                         InputPixelType;
+  typedef float                                       OutputPixelComponentType;
+  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
+                                                      OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                    NeighborhoodType;
+
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    FilterType::RealType minDistance = std::atof( argv[7] );
+    FilterType::RealType maxDistance = std::atof( argv[8] );
+    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
-
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
-
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      filter->SetDistanceValueMinMax(std::atof(argv[7]),std::atof(argv[8]));
-      hood.SetRadius( std::atoi(argv[9]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
-
-    typedef itk::Image< float, 3 > imageFeatures;
-    typedef itk::VectorIndexSelectionCastImageFilter<OutputImageType, imageFeatures > IndexSelectionType;
-    IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-    indexSelectionFilter->SetInput(filter->GetOutput());
-
-    for(unsigned int i=0; i<10; i++)
-      {
-      indexSelectionFilter->SetIndex(i);
-
-      // Create and setup a writter
-      typedef  itk::ImageFileWriter< imageFeatures > WriterType;
-      WriterType::Pointer writer = WriterType::New();
-      std::string outputFilename = argv[3];
-      std::ostringstream ss;
-      ss << i;
-      std::string s = ss.str();
-      writer->SetFileName(outputFilename + "_" + s + ".nrrd");
-      writer->SetInput(indexSelectionFilter->GetOutput());
-      writer->UpdateLargestPossibleRegion();
-      }
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
 
+  typedef itk::Image< OutputPixelComponentType, ImageDimension > FeatureImageType;
+  typedef itk::VectorIndexSelectionCastImageFilter<
+    OutputImageType, FeatureImageType > IndexSelectionType;
+  IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
+  indexSelectionFilter->SetInput( filter->GetOutput() );
+
+  for( unsigned int i = 0; i < VectorComponentDimension; i++ )
+    {
+    indexSelectionFilter->SetIndex(i);
+
+    // Create and set up a writer
+    typedef itk::ImageFileWriter< FeatureImageType > WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    std::string outputFilename = argv[3];
+    std::ostringstream ss;
+    ss << i;
+    std::string s = ss.str();
+    writer->SetFileName( outputFilename + "_" + s + ".nrrd" );
+    writer->SetInput( indexSelectionFilter->GetOutput() );
+
+    TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+    }
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToRunLengthFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/ScalarImageToRunLengthFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -25,63 +25,103 @@
 #include "itkVectorIndexSelectionCastImageFilter.h"
 #include "itkVectorImageToImageAdaptor.h"
 #include "itkNthElementImageAdaptor.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToRunLengthFeaturesImageFilterTestVectorImageSeparateFeatures(int argc, char * argv[])
+int ScalarImageToRunLengthFeaturesImageFilterTestVectorImageSeparateFeatures( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::VectorImage< float , 3 >               OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [minDistance]"
+      << " [maxDistance]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 10;
+
+  // Declare types
+  typedef int                                         InputPixelType;
+  typedef float                                       OutputPixelComponentType;
+  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
+                                                      OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                    NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    FilterType::RealType minDistance = std::atof( argv[7] );
+    FilterType::RealType maxDistance = std::atof( argv[8] );
+    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
-
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
-
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      filter->SetDistanceValueMinMax(std::atof(argv[7]),std::atof(argv[8]));
-      hood.SetRadius( std::atoi(argv[9]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
-
-    typedef itk::Image< float, 3 > imageFeatures;
-    typedef itk::VectorIndexSelectionCastImageFilter<OutputImageType, imageFeatures > IndexSelectionType;
-    IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-    indexSelectionFilter->SetInput(filter->GetOutput());
-
-    for(unsigned int i=0; i<10; i++)
-      {
-      indexSelectionFilter->SetIndex(i);
-
-      // Create and setup a writter
-      typedef  itk::ImageFileWriter< imageFeatures > WriterType;
-      WriterType::Pointer writer = WriterType::New();
-      std::string outputFilename = argv[3];
-      std::ostringstream ss;
-      ss << i;
-      std::string s = ss.str();
-      writer->SetFileName(outputFilename + "_" + s + ".nrrd");
-      writer->SetInput(indexSelectionFilter->GetOutput());
-      writer->UpdateLargestPossibleRegion();
-      }
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
 
+  typedef itk::Image< OutputPixelComponentType, ImageDimension > FeatureImageType;
+  typedef itk::VectorIndexSelectionCastImageFilter<
+    OutputImageType, FeatureImageType > IndexSelectionType;
+  IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
+  indexSelectionFilter->SetInput( filter->GetOutput() );
+
+  for( unsigned int i = 0; i < VectorComponentDimension; i++ )
+    {
+    indexSelectionFilter->SetIndex(i);
+
+    // Create and set up a writer
+    typedef itk::ImageFileWriter< FeatureImageType > WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    std::string outputFilename = argv[3];
+    std::ostringstream ss;
+    ss << i;
+    std::string s = ss.str();
+    writer->SetFileName( outputFilename + "_" + s + ".nrrd" );
+    writer->SetInput( indexSelectionFilter->GetOutput() );
+
+    TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+    }
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToRunLengthFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/ScalarImageToRunLengthFeaturesImageFilterTestWithVectorImage.cxx
@@ -22,49 +22,88 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToRunLengthFeaturesImageFilterTestWithVectorImage(int argc, char * argv[])
+int ScalarImageToRunLengthFeaturesImageFilterTestWithVectorImage( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::VectorImage< float, 3 >                OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [minDistance]"
+      << " [maxDistance]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+
+  // Declare types
+  typedef int   InputPixelType;
+  typedef float OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
+  typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >              ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                          NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( filter, ScalarImageToRunLengthFeaturesImageFilter,
+    ImageToImageFilter );
+
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    FilterType::RealType minDistance = std::atof( argv[7] );
+    FilterType::RealType maxDistance = std::atof( argv[8] );
+    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
+  // Create and set up a writer
+  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( argv[3] );
+  writer->SetInput( filter->GetOutput() );
 
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToRunLengthFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      filter->SetDistanceValueMinMax(std::atof(argv[7]),std::atof(argv[8]));
-      hood.SetRadius( std::atoi(argv[9]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-    // Create and setup a writter
-    typedef  itk::ImageFileWriter< OutputImageType  > WriterType;
-    WriterType::Pointer writer = WriterType::New();
-    std::string outputFilename = argv[3];
-    writer->SetFileName(outputFilename.c_str());
-    writer->SetInput(filter->GetOutput());
-    writer->UpdateLargestPossibleRegion();
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/ScalarImageToTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -23,62 +23,98 @@
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
 #include "itkVectorIndexSelectionCastImageFilter.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToTextureFeaturesImageFilterTestSeparateFeatures(int argc, char * argv[])
+int ScalarImageToTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::Image< itk::Vector< float, 8 > , 3 >   OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 8;
+
+  // Declare types
+  typedef int                                         InputPixelType;
+  typedef float                                       OutputPixelComponentType;
+  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
+                                                      OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                    NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType min = std::atof( argv[5] );
+    FilterType::PixelType max = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( min, max );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
-
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
-
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      hood.SetRadius( std::atoi(argv[7]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
-
-    typedef itk::Image< float, 3 > imageFeatures;
-    typedef itk::VectorIndexSelectionCastImageFilter<OutputImageType, imageFeatures > IndexSelectionType;
-    IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-    indexSelectionFilter->SetInput(filter->GetOutput());
-
-    for(unsigned int i=0; i<8; i++)
-      {
-      indexSelectionFilter->SetIndex(i);
-
-      // Create and setup a writter
-      typedef  itk::ImageFileWriter< imageFeatures > WriterType;
-      WriterType::Pointer writer = WriterType::New();
-      std::string outputFilename = argv[3];
-      std::ostringstream ss;
-      ss << i +1;
-      std::string s = ss.str();
-      writer->SetFileName(outputFilename + "_1" + s + ".nrrd");
-      writer->SetInput(indexSelectionFilter->GetOutput());
-      writer->UpdateLargestPossibleRegion();
-      }
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
 
+  typedef itk::Image< OutputPixelComponentType, ImageDimension > FeatureImageType;
+  typedef itk::VectorIndexSelectionCastImageFilter<
+    OutputImageType, FeatureImageType > IndexSelectionType;
+  IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
+  indexSelectionFilter->SetInput( filter->GetOutput() );
+
+  for( unsigned int i = 0; i < VectorComponentDimension; i++ )
+    {
+    indexSelectionFilter->SetIndex(i);
+
+    // Create and set up a writer
+    typedef itk::ImageFileWriter< FeatureImageType > WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    std::string outputFilename = argv[3];
+    std::ostringstream ss;
+    ss << i + 1;
+    std::string s = ss.str();
+    writer->SetFileName( outputFilename + "_1" + s + ".nrrd" );
+    writer->SetInput( indexSelectionFilter->GetOutput() );
+
+    TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+    }
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/ScalarImageToTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -25,62 +25,95 @@
 #include "itkVectorIndexSelectionCastImageFilter.h"
 #include "itkVectorImageToImageAdaptor.h"
 #include "itkNthElementImageAdaptor.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToTextureFeaturesImageFilterTestVectorImageSeparateFeatures(int argc, char * argv[])
+int ScalarImageToTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::VectorImage< float , 3 >               OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 8;
+
+  // Declare types
+  typedef int   InputPixelType;
+  typedef float OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
+  typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >              ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                          NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
-
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
-
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      hood.SetRadius( std::atoi(argv[7]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
-
-    typedef itk::Image< float, 3 > imageFeatures;
-    typedef itk::VectorIndexSelectionCastImageFilter<OutputImageType, imageFeatures > IndexSelectionType;
-    IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
-    indexSelectionFilter->SetInput(filter->GetOutput());
-
-    for(unsigned int i=0; i<8; i++)
-      {
-      indexSelectionFilter->SetIndex(i);
-
-      // Create and setup a writter
-      typedef  itk::ImageFileWriter< imageFeatures > WriterType;
-      WriterType::Pointer writer = WriterType::New();
-      std::string outputFilename = argv[3];
-      std::ostringstream ss;
-      ss << i + 1;
-      std::string s = ss.str();
-      writer->SetFileName(outputFilename + "_1" + s + ".nrrd");
-      writer->SetInput(indexSelectionFilter->GetOutput());
-      writer->UpdateLargestPossibleRegion();
-      }
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
 
+  typedef itk::Image< OutputPixelType, ImageDimension > FeatureImageType;
+  typedef itk::VectorIndexSelectionCastImageFilter<
+    OutputImageType, FeatureImageType > IndexSelectionType;
+  IndexSelectionType::Pointer indexSelectionFilter = IndexSelectionType::New();
+  indexSelectionFilter->SetInput( filter->GetOutput() );
+
+  for( unsigned int i = 0; i < VectorComponentDimension; i++ )
+    {
+    indexSelectionFilter->SetIndex(i);
+
+    // Create and setup a writer
+    typedef itk::ImageFileWriter< FeatureImageType > WriterType;
+    WriterType::Pointer writer = WriterType::New();
+    std::string outputFilename = argv[3];
+    std::ostringstream ss;
+    ss << i + 1;
+    std::string s = ss.str();
+    writer->SetFileName( outputFilename + "_1" + s + ".nrrd" );
+    writer->SetInput( indexSelectionFilter->GetOutput() );
+
+    TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+    }
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/ScalarImageToTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -22,48 +22,82 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToTextureFeaturesImageFilterTestWithVectorImage(int argc, char * argv[])
+int ScalarImageToTextureFeaturesImageFilterTestWithVectorImage( int argc, char *argv[] )
 {
-    // Setup types
-    typedef itk::Image< int, 3 >                        InputImageType;
-    typedef itk::VectorImage< float, 3 >                OutputImageType;
-    typedef itk::ImageFileReader< InputImageType >      readerType;
-    typedef itk::Neighborhood<typename InputImageType::PixelType,
-      InputImageType::ImageDimension> NeighborhoodType;
+  if( argc < 4 )
+    {
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " maskImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  const unsigned int ImageDimension = 3;
+
+  // Declare types
+  typedef int   InputPixelType;
+  typedef float OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
+  typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >              ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                          NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create and set up a maskReader
+  ReaderType::Pointer maskReader = ReaderType::New();
+  maskReader->SetFileName( argv[2] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  EXERCISE_BASIC_OBJECT_METHODS( filter, ScalarImageToTextureFeaturesImageFilter,
+    ImageToImageFilter );
+
+
+  filter->SetInput( reader->GetOutput() );
+  filter->SetMaskImage( maskReader->GetOutput() );
+
+  if( argc >= 5 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
 
-    // Create and setup a reader
-    readerType::Pointer reader = readerType::New();
-    std::string inputFilename = argv[1];
-    reader->SetFileName( inputFilename.c_str() );
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
 
-    // Create and setup a maskReader
-    readerType::Pointer maskReader = readerType::New();
-    std::string maskFilename = argv[2];
-    maskReader->SetFileName( maskFilename.c_str() );
+  // Create and set up a writer
+  typedef itk::ImageFileWriter< OutputImageType > WriterType;
+  WriterType::Pointer writer = WriterType::New();
+  writer->SetFileName( argv[3] );
+  writer->SetInput( filter->GetOutput() );
 
-    // Apply the filter
-    typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-    FilterType::Pointer filter = FilterType::New();
-    filter->SetInput(reader->GetOutput());
-    filter->SetMaskImage(maskReader->GetOutput());
-    if(argc >= 5)
-      {
-      filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-      filter->SetPixelValueMinMax(std::atof(argv[5]),std::atof(argv[6]));
-      hood.SetRadius( std::atoi(argv[7]) );
-      filter->SetNeighborhoodRadius(hood.GetRadius());
-      }
-    filter->UpdateLargestPossibleRegion();
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
 
-    // Create and setup a writter
-    typedef  itk::ImageFileWriter< OutputImageType  > WriterType;
-    WriterType::Pointer writer = WriterType::New();
-    std::string outputFilename = argv[3];
-    writer->SetFileName(outputFilename.c_str());
-    writer->SetInput(filter->GetOutput());
-    writer->UpdateLargestPossibleRegion();
 
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/test/ScalarImageToTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/ScalarImageToTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -22,42 +22,75 @@
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkNeighborhood.h"
+#include "itkTestingMacros.h"
 
-int ScalarImageToTextureFeaturesImageFilterTestWithoutMask(int argc, char * argv[])
+int ScalarImageToTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[] )
 {
-  // Setup types
-  typedef itk::Image< int, 3 >                        InputImageType;
-  typedef itk::Image< itk::Vector< float, 8 > , 3 >   OutputImageType;
-  typedef itk::ImageFileReader< InputImageType >      readerType;
-  typedef itk::Neighborhood<typename InputImageType::PixelType,
-    InputImageType::ImageDimension> NeighborhoodType;
-  NeighborhoodType hood;
-
-  // Create and setup a reader
-  readerType::Pointer reader = readerType::New();
-  std::string inputFilename = argv[1];
-  reader->SetFileName( inputFilename.c_str() );
-
-  // Apply the filter
-  typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter< InputImageType, OutputImageType > FilterType;
-  FilterType::Pointer filter = FilterType::New();
-  filter->SetInput(reader->GetOutput());
-  if(argc >= 4)
+  if( argc < 3 )
     {
-    filter->SetNumberOfBinsPerAxis(std::atoi(argv[3]));
-    filter->SetPixelValueMinMax(std::atof(argv[4]),std::atof(argv[5]));
-    hood.SetRadius( std::atoi(argv[6]) );
-    filter->SetNeighborhoodRadius(hood.GetRadius());
+    std::cerr << "Missing parameters." << std::endl;
+    std::cerr << "Usage: " << argv[0]
+      << " inputImageFile"
+      << " outputImageFile"
+      << " [numberOfBinsPerAxis]"
+      << " [pixelValueMin]"
+      << " [pixelValueMax]"
+      << " [neighborhoodRadius]" << std::endl;
+    return EXIT_FAILURE;
     }
-  filter->UpdateLargestPossibleRegion();
 
-  // Create and setup a writter
-  typedef  itk::ImageFileWriter< OutputImageType  > WriterType;
+  const unsigned int ImageDimension = 3;
+  const unsigned int VectorComponentDimension = 8;
+
+  // Declare types
+  typedef int                                           InputPixelType;
+  typedef float                                         OutputPixelComponentType;
+  typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
+                                                        OutputPixelType;
+
+  typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
+  typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::Neighborhood< typename InputImageType::PixelType,
+    InputImageType::ImageDimension >                    NeighborhoodType;
+
+  // Create and set up a reader
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName( argv[1] );
+
+  // Create the filter
+  typedef itk::Statistics::ScalarImageToTextureFeaturesImageFilter<
+    InputImageType, OutputImageType > FilterType;
+  FilterType::Pointer filter = FilterType::New();
+
+  filter->SetInput( reader->GetOutput() );
+
+  if( argc >= 4 )
+    {
+    unsigned int numberOfBinsPerAxis = std::atoi( argv[3] );
+    filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
+
+    FilterType::PixelType pixelValueMin = std::atof( argv[4] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[5] );
+    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[6] );
+    NeighborhoodType hood;
+    hood.SetRadius( neighborhoodRadius );
+    filter->SetNeighborhoodRadius( hood.GetRadius() );
+    }
+
+  TRY_EXPECT_NO_EXCEPTION( filter->Update() );
+
+  // Create and set up a writer
+  typedef itk::ImageFileWriter< OutputImageType > WriterType;
   WriterType::Pointer writer = WriterType::New();
-  std::string outputFilename = argv[2];
-  writer->SetFileName(outputFilename.c_str());
-  writer->SetInput(filter->GetOutput());
-  writer->UpdateLargestPossibleRegion();
+  writer->SetFileName( argv[2] );
+  writer->SetInput( filter->GetOutput() );
 
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
+
+  std::cout << "Test finished." << std::endl;
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Increase code coverage:
- Exercise basic object methods.
- Check all Set/Get methods consistently using the TEST_SET_GET_VALUE
macro. Use variables to hold the tested values.

Check the input argument list and display a usage message in case of
error.

Use the TRY_EXPECT_NO_EXCEPTION macro to surround filter update calls.

Remove unnecessary variables (e.g. filename strings) to save
typing/increase readability.

Style changes to make testing consistent across the toolkit, and make
the code more readable:
- Declare the input/output image dimensions as constants
- Declare the pixel types.
- Capitalize the typedef aliases.
- Reduce indentation to the two space standard.
- Use white spaces and CR/LFs to increase readaibility.