### PR TITLE
BUG: Fix failing to allocate memory for output image.

### DIFF
--- a/include/itkScalarImageToRunLengthFeaturesImageFilter.hxx
+++ b/include/itkScalarImageToRunLengthFeaturesImageFilter.hxx
@@ -59,12 +59,6 @@ ScalarImageToRunLengthFeaturesImageFilter< TInputImage, TOutputImage >
   NeighborhoodType nhood;
   nhood.SetRadius( 2 );
   this->m_NeighborhoodRadius = nhood.GetRadius( );
-
-  TOutputImage      *outputPtr = this->GetOutput();
-  typename TOutputImage::PixelType pixelNull;
-  pixelNull.Fill(0);
-  outputPtr->FillBuffer( pixelNull );
-
 }
 
 template<typename TInputImage, typename TOutputImage>

--- a/include/itkScalarImageToTextureFeaturesImageFilter.hxx
+++ b/include/itkScalarImageToTextureFeaturesImageFilter.hxx
@@ -58,10 +58,6 @@ ScalarImageToTextureFeaturesImageFilter< TInputImage, TOutputImage >
   nhood.SetRadius( 2 );
   this->m_NeighborhoodRadius = nhood.GetRadius( );
 
-  TOutputImage      *outputPtr = this->GetOutput();
-  typename TOutputImage::PixelType pixelNull;
-  pixelNull.Fill(0);
-  outputPtr->FillBuffer( pixelNull );
   this->m_Normalize = false;
 }
 


### PR DESCRIPTION
Add missing call to Allocate for the ouput image pointer in the
constructor. Classes were not able to be instances and a run-time error
was being thrown.