### PR TITLE
COMP: Use itk::Math::abs instead of std::abs

### DIFF
--- a/include/itkScalarImageToRunLengthFeaturesImageFilter.hxx
+++ b/include/itkScalarImageToRunLengthFeaturesImageFilter.hxx
@@ -374,7 +374,7 @@ ScalarImageToRunLengthFeaturesImageFilter<TInputImage, TOutputImage>
   bool insideNeighborhood = true;
   for ( unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i )
     {
-    int boundDistance = m_NeighborhoodRadius[i] - std::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - Math::abs(iteratedOffset[i]);
     if(boundDistance < 0)
       {
       insideNeighborhood = false;

--- a/include/itkScalarImageToTextureFeaturesImageFilter.hxx
+++ b/include/itkScalarImageToTextureFeaturesImageFilter.hxx
@@ -305,7 +305,7 @@ ScalarImageToTextureFeaturesImageFilter<TInputImage, TOutputImage>
   bool insideNeighborhood = true;
   for ( unsigned int i = 0; i < this->m_NeighborhoodRadius.Dimension; ++i )
     {
-    int boundDistance = m_NeighborhoodRadius[i] - std::abs(iteratedOffset[i]);
+    int boundDistance = m_NeighborhoodRadius[i] - Math::abs(iteratedOffset[i]);
     if(boundDistance < 0)
       {
       insideNeighborhood = false;


### PR DESCRIPTION
itk::Math::abs is defined for integer arguments while std::abs is not for all
compilers.