### PR TITLE
COMP: Address typename outside of template warnings.

### DIFF
--- a/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
@@ -45,7 +45,7 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
 

--- a/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
@@ -47,7 +47,7 @@ int CoocurrenceTextureFeaturesImageFilterTest( int argc, char *argv[] )
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader

--- a/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -53,7 +53,7 @@ int CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *a
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader

--- a/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -53,7 +53,7 @@ int CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int ar
   typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
   typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >              ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                          NeighborhoodType;
 
   // Create and set up a reader

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -49,7 +49,7 @@ int CoocurrenceTextureFeaturesImageFilterTestWithVectorImage( int argc, char *ar
   typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
   typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >              ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                          NeighborhoodType;
 
   // Create and set up a reader

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -51,7 +51,7 @@ int CoocurrenceTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[]
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader

--- a/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
@@ -45,7 +45,7 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
 

--- a/test/RunLengthTextureFeaturesImageFilterTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTest.cxx
@@ -54,7 +54,7 @@ int RunLengthTextureFeaturesImageFilterTest( int argc, char *argv[] )
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader

--- a/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -55,7 +55,7 @@ int RunLengthTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *arg
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
 

--- a/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -57,7 +57,7 @@ int RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int argc
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader

--- a/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -51,7 +51,7 @@ int RunLengthTextureFeaturesImageFilterTestWithVectorImage( int argc, char *argv
   typedef itk::Image< InputPixelType, ImageDimension >        InputImageType;
   typedef itk::VectorImage< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >              ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                          NeighborhoodType;
 
   // Create and set up a reader

--- a/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -53,7 +53,7 @@ int RunLengthTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[] )
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
-  typedef itk::Neighborhood< typename InputImageType::PixelType,
+  typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
   // Create and set up a reader


### PR DESCRIPTION
These occur with recent clang. For example:

/home/matt/src/ITKTextureFeatures/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx:48:30: warning: 'typename' occurs outside of a template [-Wc++11-extensions]
  typedef itk::Neighborhood< typename InputImageType::PixelType,
                             ^~~~~~~~~

Also address result unused warning:
In file included from /home/matt/src/ITKTextureFeatures/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx:18:
In file included from /home/matt/src/ITK/Modules/Remote/TextureFeatures/include/itkRunLengthTextureFeaturesImageFilter.h:261:
/home/matt/src/ITK/Modules/Remote/TextureFeatures/include/itkRunLengthTextureFeaturesImageFilter.hxx:189:9: warning: expression result unused [-Wunused-value]
  for ( fit; fit != faceList.end(); ++fit )
        ^~~