### PR TITLE
Fix itk version required for GTest

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -10,7 +10,7 @@ file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 # By convention those modules outside of ITK are not prefixed with
 # ITK.
 
-if( NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.12" )
+if( NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.13" )
   set(_GoogleTest_DEPENDS ITKGoogleTest)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,7 +251,7 @@ itk_add_test(NAME itkFirstOrderTextureFeaturesImageFilterTest1
           5
       )
 
-if( NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.12" )
+if( NOT "${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}" VERSION_LESS "4.13" )
   set(TextureFeaturesGTests
     itkFirstOrderTextureFeaturesImageFilterGTest.cxx
     )

--- a/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
+++ b/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
@@ -40,7 +40,7 @@ out << "entropy: " << p[7] << std::endl;
 
 }
 
-TEST(TextTureFeatures, FirstOrder_Test1)
+TEST(TextureFeatures, FirstOrder_Test1)
 {
   const unsigned int ImageDimension = 2;
   typedef itk::Image<float, ImageDimension >                    ImageType;
@@ -110,7 +110,7 @@ TEST(TextTureFeatures, FirstOrder_Test1)
 }
 
 
-TEST(TextTureFeatures, FirstOrder_Test2)
+TEST(TextureFeatures, FirstOrder_Test2)
 {
   const unsigned int ImageDimension = 2;
   typedef itk::Image<float, ImageDimension >                    ImageType;


### PR DESCRIPTION
When used with ITK 4.12, the GTest dependency should no longer appear.