### PR TITLE
BUG: Filling the output image even for voxels outside of the mask

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
@@ -180,6 +180,8 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
       // If the voxel is outside of the mask, don't treat it
       if( inputNIt.GetCenterPixel() < ( - 5) ) //the pixel is outside of the mask
         {
+        outputPixel.Fill(0);
+        outputIt.Set(outputPixel);
         progress.CompletedPixel();
         ++inputNIt;
         ++outputIt;

--- a/include/itkRunLengthTextureFeaturesImageFilter.hxx
+++ b/include/itkRunLengthTextureFeaturesImageFilter.hxx
@@ -200,6 +200,8 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
       // If the voxel is outside of the mask, don't treat it
       if( inputNIt.GetCenterPixel() < ( - 5) ) //the pixel is outside of the mask
         {
+        outputPixel.Fill(0);
+        outputIt.Set(outputPixel);
         progress.CompletedPixel();
         ++inputNIt;
         ++outputIt;


### PR DESCRIPTION
This fix prevents the failure of tests 18 to 21 on windows: https://open.cdash.org/viewTest.php?onlyfailed&buildid=4995219