### PR TITLE
BUG: Add missing setters  for min and max variable

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -45,7 +45,7 @@ namespace Statistics
  *
  * Template Parameters:
  * -# The input image type: a N dimensional image where the pixel type MUST be integer.
- * -# The output image type: a N dimensional image where the pixel type MUST be a vector of floating points or an ImageVector.
+ * -# The output image type: a N dimensional image where the pixel type MUST be a vector of floating points or a VectorImage.
  *
  * Inputs and parameters:
  * -# An image
@@ -170,17 +170,13 @@ public:
   /** Get number of histogram bins along each axis */
   itkGetConstMacro( NumberOfBinsPerAxis, unsigned int );
 
-  /**
-   * Set the min and max (inclusive) pixel value that will be used in
-   * generating the histogram.
-   */
-  void SetPixelValueMinMax( PixelType min, PixelType max );
+  /** Get the max pixel value defining one dimension of the joint histogram. */
+  itkGetConstMacro( HistogramMaximum, PixelType );
+  itkSetMacro( HistogramMaximum, PixelType);
 
   /** Get the min pixel value defining one dimension of the joint histogram. */
-  itkGetConstMacro( Min, PixelType );
-
-  /** Get the max pixel value defining one dimension of the joint histogram. */
-  itkGetConstMacro( Max, PixelType );
+  itkGetConstMacro( HistogramMinimum, PixelType );
+  itkSetMacro( HistogramMinimum, PixelType);
 
   /**
    * Set the pixel value of the mask that should be considered "inside" the
@@ -236,8 +232,8 @@ private:
   NeighborhoodRadiusType            m_NeighborhoodRadius;
   OffsetVectorPointer               m_Offsets;
   unsigned int                      m_NumberOfBinsPerAxis;
-  PixelType                         m_Min;
-  PixelType                         m_Max;
+  PixelType                         m_HistogramMinimum;
+  PixelType                         m_HistogramMaximum;
   PixelType                         m_InsidePixelValue;
   bool                              m_Normalize;
 

--- a/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
@@ -31,8 +31,8 @@ template< typename TInputImage, typename TOutputImage>
 CoocurrenceTextureFeaturesImageFilter< TInputImage, TOutputImage >
 ::CoocurrenceTextureFeaturesImageFilter() :
     m_NumberOfBinsPerAxis( itkGetStaticConstMacro( DefaultBinsPerAxis ) ),
-    m_Min( NumericTraits<PixelType>::NonpositiveMin() ),
-    m_Max( NumericTraits<PixelType>::max() ),
+    m_HistogramMinimum( NumericTraits<PixelType>::NonpositiveMin() ),
+    m_HistogramMaximum( NumericTraits<PixelType>::max() ),
     m_InsidePixelValue( NumericTraits<PixelType>::OneValue() )
 {
   this->SetNumberOfRequiredInputs( 1 );
@@ -89,7 +89,7 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   input->Graft(const_cast<TInputImage *>(this->GetInput()));
 
   typedef PreProcessingFunctor PPFType;
-  PPFType ppf(m_NumberOfBinsPerAxis, m_InsidePixelValue, m_Min, m_Max);
+  PPFType ppf(m_NumberOfBinsPerAxis, m_InsidePixelValue, m_HistogramMinimum, m_HistogramMaximum);
 
   typedef BinaryFunctorImageFilter< MaskImageType, InputImageType, InputImageType, PPFType> BinaryFunctorType;
   typename BinaryFunctorType::Pointer functorF = BinaryFunctorType::New();
@@ -261,20 +261,6 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   if ( output->GetNumberOfComponentsPerPixel() != 8 )
     {
     output->SetNumberOfComponentsPerPixel( 8 );
-    }
-}
-
-
-template<typename TInputImage, typename TOutputImage>
-void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
-::SetPixelValueMinMax( PixelType min, PixelType max )
-{
-  if( this->m_Min != min || this->m_Max != max )
-    {
-    this->m_Min = min;
-    this->m_Max = max;
-    this->Modified();
     }
 }
 
@@ -468,10 +454,10 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
 
   os << indent << "NumberOfBinsPerAxis: " << m_NumberOfBinsPerAxis << std::endl;
   os << indent << "Min: "
-    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_Min )
+    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_HistogramMinimum )
     << std::endl;
   os << indent << "Max: "
-    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_Max )
+    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_HistogramMaximum )
     << std::endl;
   os << indent << "InsidePixelValue: "
     << static_cast< typename NumericTraits< PixelType >::PrintType >(

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -34,8 +34,10 @@ namespace Statistics
  * This filter computes a N-D image where each voxel will contain
  * a vector of up to 10 scalars representing the run length features
  * (of the specified neighborhood) from a N-D scalar image.
- * The run length features are computed for each spatial
- * direction and averaged afterward.
+ * The run length features are computed from joint histograms of
+ * pixel intensities and distance (run length) per spatial direction
+ * then averaged afterward.
+ *
  * The result obtained is a possible texture description. See the following references.
  * M. M. Galloway. Texture analysis using gray level run lengths. Computer
  * Graphics and Image Processing, 4:172-179, 1975.
@@ -50,7 +52,7 @@ namespace Statistics
  *
  * Template Parameters:
  * -# The input image type: a N dimensional image where the pixel type MUST be integer.
- * -# The output image type: a N dimensional image where the pixel type MUST be a vector of floating points or an ImageVector.
+ * -# The output image type: a N dimensional image where the pixel type MUST be a vector of floating points or a VectorImage.
  *
  * Inputs and parameters:
  * -# An image
@@ -62,10 +64,12 @@ namespace Statistics
  * -# The set of directions (offsets) to average across. (Optional, defaults to
  *    {(-1, 0), (-1, -1), (0, -1), (1, -1)} for 2D images and scales analogously
  *    for ND images.)
- * -# The pixel intensity range over which the features will be calculated.
- *    (Optional, defaults to the full dynamic range of the pixel type.)
- * -# The distance range over which the features will be calculated.
- *    (Optional, defaults to the full dynamic range of double type.)
+ * -# The pixel intensity range for the joint histogram over which the
+ *    features will be calculated. (Optional, defaults to the full
+ *    dynamic range of the pixel type.)
+ * -# The distance range for the joint histogram over which the
+ *    features will be calculated. (Optional, defaults to the full
+ *    dynamic range of double type.)
  * -# The size of the neighborhood radius. (Optional, defaults to 2.)
  *
  * Recommendations:
@@ -175,33 +179,30 @@ public:
   /** Get number of histogram bins along each axis */
   itkGetConstMacro( NumberOfBinsPerAxis, unsigned int );
 
-  /**
-   * Set the min and max (inclusive) pixel value that will be used in
-   * generating the histogram.
-   */
-  void SetPixelValueMinMax( PixelType min, PixelType max );
+  /** Set/Get the minimum (inclusive) pixel value defining one dimension of the joint
+   * value distance histogram. */
+  itkGetConstMacro( HistogramValueMinimum, PixelType );
+  itkSetMacro( HistogramValueMinimum, PixelType);
 
-  /** Get the min pixel value defining one dimension of the joint histogram. */
-  itkGetConstMacro( Min, PixelType );
+  /** Set/Get the maximum pixel value defining one dimension of the joint
+   * value distance histogram. */
+  itkGetConstMacro( HistogramValueMaximum, PixelType );
+  itkSetMacro( HistogramValueMaximum, PixelType);
 
-  /** Get the max pixel value defining one dimension of the joint histogram. */
-  itkGetConstMacro( Max, PixelType );
-
-  /**
-   * Set the min and max (inclusive) pixel value that will be used in
-   * generating the histogram.
-   */
-  void SetDistanceValueMinMax( RealType min, RealType max );
 
   /**
-   * Get the min distance value defining one dimension of the joint histogram.
+   * Set/Get the minimum (inclusive) run length distance in physical
+   * space that will be used in generating the joint value distance histogram.
    */
-  itkGetConstMacro( MinDistance, RealType );
+  itkGetConstMacro( HistogramDistanceMinimum, RealType );
+  itkSetMacro( HistogramDistanceMinimum, RealType);
 
-  /**
-   * Get the max distance value defining one dimension of the joint histogram.
+ /**
+   * Set/Get the maximum  run length distance in physical
+   * space that will be used in generating the joint value distance histogram.
    */
-  itkGetConstMacro( MaxDistance, RealType );
+  itkGetConstMacro( HistogramDistanceMaximum, RealType );
+  itkSetMacro( HistogramDistanceMaximum, RealType);
 
   /**
    * Set the pixel value of the mask that should be considered "inside" the
@@ -247,10 +248,10 @@ private:
   NeighborhoodRadiusType            m_NeighborhoodRadius;
   OffsetVectorPointer               m_Offsets;
   unsigned int                      m_NumberOfBinsPerAxis;
-  PixelType                         m_Min;
-  PixelType                         m_Max;
-  RealType                          m_MinDistance;
-  RealType                          m_MaxDistance;
+  PixelType                         m_HistogramValueMinimum;
+  PixelType                         m_HistogramValueMaximum;
+  RealType                          m_HistogramDistanceMinimum;
+  RealType                          m_HistogramDistanceMaximum;
   PixelType                         m_InsidePixelValue;
   typename TInputImage::SpacingType m_Spacing;
 };

--- a/include/itkRunLengthTextureFeaturesImageFilter.hxx
+++ b/include/itkRunLengthTextureFeaturesImageFilter.hxx
@@ -30,10 +30,10 @@ template< typename TInputImage, typename TOutputImage>
 RunLengthTextureFeaturesImageFilter< TInputImage, TOutputImage >
 ::RunLengthTextureFeaturesImageFilter() :
     m_NumberOfBinsPerAxis( itkGetStaticConstMacro( DefaultBinsPerAxis ) ),
-    m_Min( NumericTraits<PixelType>::NonpositiveMin() ),
-    m_Max( NumericTraits<PixelType>::max() ),
-    m_MinDistance( NumericTraits<RealType>::ZeroValue() ),
-    m_MaxDistance( NumericTraits<RealType>::max() ),
+    m_HistogramValueMinimum( NumericTraits<PixelType>::NonpositiveMin() ),
+    m_HistogramValueMaximum( NumericTraits<PixelType>::max() ),
+    m_HistogramDistanceMinimum( NumericTraits<RealType>::ZeroValue() ),
+    m_HistogramDistanceMaximum( NumericTraits<RealType>::max() ),
     m_InsidePixelValue( NumericTraits<PixelType>::OneValue() ),
     m_Spacing( 1.0 )
 {
@@ -95,13 +95,13 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
       {
       digitIt.Set(-10);
       }
-    else if(inputIt.Get() < this->m_Min || inputIt.Get() >= this->m_Max)
+    else if(inputIt.Get() < this->m_HistogramValueMinimum || inputIt.Get() >= this->m_HistogramValueMinimum)
       {
       digitIt.Set(-1);
       }
     else
       {
-      binNumber = ( inputIt.Get() - m_Min)/( (m_Max - m_Min) / (float)m_NumberOfBinsPerAxis );
+      binNumber = ( inputIt.Get() - m_HistogramValueMinimum)/( (m_HistogramValueMaximum - m_HistogramValueMinimum) / (float)m_NumberOfBinsPerAxis );
       digitIt.Set(binNumber);
       }
     ++inputIt;
@@ -331,32 +331,6 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 template<typename TInputImage, typename TOutputImage>
 void
 RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
-::SetPixelValueMinMax( PixelType min, PixelType max )
-{
-  if( this->m_Min != min || this->m_Max != max )
-    {
-    this->m_Min = min;
-    this->m_Max = max;
-    this->Modified();
-    }
-}
-
-template<typename TInputImage, typename TOutputImage>
-void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
-::SetDistanceValueMinMax( RealType min, RealType max )
-{
-  if( Math::NotExactlyEquals(this->m_MinDistance, min) || Math::NotExactlyEquals(this->m_MaxDistance, max) )
-    {
-    this->m_MinDistance = min;
-    this->m_MaxDistance = max;
-    this->Modified();
-    }
-}
-
-template<typename TInputImage, typename TOutputImage>
-void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 ::NormalizeOffsetDirection(OffsetType &offset)
 {
   itkDebugMacro("old offset = " << offset << std::endl);
@@ -409,8 +383,8 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
     offsetDistance += (offset[i]*m_Spacing[i])*(offset[i]*m_Spacing[i]);
     }
   offsetDistance = std::sqrt(offsetDistance);
-  int offsetDistanceBin = static_cast< int>(( offsetDistance*pixelDistance - m_MinDistance)/
-          ( (m_MaxDistance - m_MinDistance) / (float)m_NumberOfBinsPerAxis ));
+  int offsetDistanceBin = static_cast< int>(( offsetDistance*pixelDistance - m_HistogramDistanceMinimum)/
+          ( (m_HistogramDistanceMaximum - m_HistogramDistanceMinimum) / (float)m_NumberOfBinsPerAxis ));
   if (offsetDistanceBin < static_cast< int >( m_NumberOfBinsPerAxis ) && offsetDistanceBin >= 0)
     {
     ++totalNumberOfRuns;
@@ -522,17 +496,17 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 
   os << indent << "NumberOfBinsPerAxis: " << m_NumberOfBinsPerAxis << std::endl;
   os << indent << "Min: "
-    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_Min )
+    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_HistogramValueMinimum )
     << std::endl;
   os << indent << "Max: "
-    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_Max )
+    << static_cast< typename NumericTraits< PixelType >::PrintType >( m_HistogramValueMaximum )
     << std::endl;
   os << indent << "MinDistance: "
     << static_cast< typename NumericTraits< RealType >::PrintType >(
-    m_MinDistance ) << std::endl;
+    m_HistogramDistanceMinimum ) << std::endl;
   os << indent << "MaxDistance: "
     << static_cast< typename NumericTraits< RealType >::PrintType >(
-    m_MaxDistance ) << std::endl;
+    m_HistogramDistanceMaximum ) << std::endl;
   os << indent << "InsidePixelValue: "
     << static_cast< typename NumericTraits< PixelType >::PrintType >(
     m_InsidePixelValue ) << std::endl;

--- a/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
@@ -79,9 +79,10 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
 
   FilterType::PixelType min = -62;
   FilterType::PixelType max = 2456;
-  filter->SetPixelValueMinMax( min, max );
-  TEST_SET_GET_VALUE( min, filter->GetMin() );
-  TEST_SET_GET_VALUE( max, filter->GetMax() );
+  filter->SetHistogramMinimum( min );
+  filter->SetHistogramMaximum( max );
+  TEST_SET_GET_VALUE( min, filter->GetHistogramMinimum() );
+  TEST_SET_GET_VALUE( max, filter->GetHistogramMaximum() );
 
   NeighborhoodType::SizeValueType neighborhoodRadius = 3;
   NeighborhoodType hood;

--- a/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
@@ -73,7 +73,8 @@ int CoocurrenceTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramMinimum( pixelValueMin );
+    filter->SetHistogramMaximum( pixelValueMax );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;

--- a/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -78,9 +78,11 @@ int CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *a
     unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType min = std::atof( argv[5] );
-    FilterType::PixelType max = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( min, max );
+    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    filter->SetHistogramMinimum( pixelValueMin );
+    filter->SetHistogramMaximum( pixelValueMax );
+
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;

--- a/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -79,7 +79,8 @@ int CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int ar
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramMinimum( pixelValueMin );
+    filter->SetHistogramMaximum( pixelValueMax );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -79,7 +79,8 @@ int CoocurrenceTextureFeaturesImageFilterTestWithVectorImage( int argc, char *ar
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramMinimum( pixelValueMin );
+    filter->SetHistogramMaximum( pixelValueMax );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
     NeighborhoodType hood;

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -72,7 +72,8 @@ int CoocurrenceTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[]
 
     FilterType::PixelType pixelValueMin = std::atof( argv[4] );
     FilterType::PixelType pixelValueMax = std::atof( argv[5] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramMinimum( pixelValueMin );
+    filter->SetHistogramMaximum( pixelValueMax );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[6] );
     NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
@@ -78,15 +78,17 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
 
   FilterType::PixelType pixelValueMin = -62;
   FilterType::PixelType pixelValueMax = 2456;
-  filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
-  TEST_SET_GET_VALUE( pixelValueMin, filter->GetMin() );
-  TEST_SET_GET_VALUE( pixelValueMax, filter->GetMax() );
+  filter->SetHistogramValueMinimum( pixelValueMin );
+  filter->SetHistogramValueMaximum( pixelValueMax );
+  TEST_SET_GET_VALUE( pixelValueMin, filter->GetHistogramValueMinimum() );
+  TEST_SET_GET_VALUE( pixelValueMax, filter->GetHistogramValueMaximum() );
 
   FilterType::RealType minDistance = 0.15;
   FilterType::RealType maxDistance = 1.5;
-  filter->SetDistanceValueMinMax( minDistance, maxDistance );
-  TEST_SET_GET_VALUE( minDistance, filter->GetMinDistance() );
-  TEST_SET_GET_VALUE( maxDistance, filter->GetMaxDistance() );
+  filter->SetHistogramDistanceMinimum( minDistance );
+  filter->SetHistogramDistanceMaximum( maxDistance );
+  TEST_SET_GET_VALUE( minDistance, filter->GetHistogramDistanceMinimum() );
+  TEST_SET_GET_VALUE( maxDistance, filter->GetHistogramDistanceMaximum() );
 
   NeighborhoodType::SizeValueType neighborhoodRadius = 3;
   NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTest.cxx
@@ -87,15 +87,17 @@ int RunLengthTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
-    TEST_SET_GET_VALUE( pixelValueMin, filter->GetMin() );
-    TEST_SET_GET_VALUE( pixelValueMax, filter->GetMax() );
+    filter->SetHistogramValueMinimum( pixelValueMin );
+    filter->SetHistogramValueMaximum( pixelValueMax );
+    TEST_SET_GET_VALUE( pixelValueMin, filter->GetHistogramValueMinimum() );
+    TEST_SET_GET_VALUE( pixelValueMax, filter->GetHistogramValueMaximum() );
 
     FilterType::RealType minDistance = std::atof( argv[7] );
     FilterType::RealType maxDistance = std::atof( argv[8] );
-    filter->SetDistanceValueMinMax( minDistance, maxDistance );
-    TEST_SET_GET_VALUE( minDistance, filter->GetMinDistance() );
-    TEST_SET_GET_VALUE( maxDistance, filter->GetMaxDistance() );
+    filter->SetHistogramDistanceMinimum( minDistance );
+    filter->SetHistogramDistanceMaximum( maxDistance );
+    TEST_SET_GET_VALUE( minDistance, filter->GetHistogramDistanceMinimum() );
+    TEST_SET_GET_VALUE( maxDistance, filter->GetHistogramDistanceMaximum() );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -82,11 +82,14 @@ int RunLengthTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *arg
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramValueMinimum( pixelValueMin );
+    filter->SetHistogramValueMaximum( pixelValueMax );
 
     FilterType::RealType minDistance = std::atof( argv[7] );
     FilterType::RealType maxDistance = std::atof( argv[8] );
-    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+    filter->SetHistogramDistanceMinimum( minDistance );
+    filter->SetHistogramDistanceMaximum( maxDistance );
+
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -83,11 +83,13 @@ int RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int argc
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramValueMinimum( pixelValueMin );
+    filter->SetHistogramValueMaximum( pixelValueMax );
 
     FilterType::RealType minDistance = std::atof( argv[7] );
     FilterType::RealType maxDistance = std::atof( argv[8] );
-    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+    filter->SetHistogramDistanceMinimum( minDistance );
+    filter->SetHistogramDistanceMaximum( maxDistance );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -81,11 +81,14 @@ int RunLengthTextureFeaturesImageFilterTestWithVectorImage( int argc, char *argv
 
     FilterType::PixelType pixelValueMin = std::atof( argv[5] );
     FilterType::PixelType pixelValueMax = std::atof( argv[6] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramValueMinimum( pixelValueMin );
+    filter->SetHistogramValueMaximum( pixelValueMax );
+
 
     FilterType::RealType minDistance = std::atof( argv[7] );
     FilterType::RealType maxDistance = std::atof( argv[8] );
-    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+    filter->SetHistogramDistanceMinimum( minDistance );
+    filter->SetHistogramDistanceMaximum( maxDistance );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
     NeighborhoodType hood;

--- a/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -75,11 +75,13 @@ int RunLengthTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[] )
 
     FilterType::PixelType pixelValueMin = std::atof( argv[4] );
     FilterType::PixelType pixelValueMax = std::atof( argv[5] );
-    filter->SetPixelValueMinMax( pixelValueMin, pixelValueMax );
+    filter->SetHistogramValueMinimum( pixelValueMin );
+    filter->SetHistogramValueMaximum( pixelValueMax );
 
     FilterType::RealType minDistance = std::atof( argv[6] );
     FilterType::RealType maxDistance = std::atof( argv[7] );
-    filter->SetDistanceValueMinMax( minDistance, maxDistance );
+    filter->SetHistogramDistanceMinimum( minDistance );
+    filter->SetHistogramDistanceMaximum( maxDistance );
 
     NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[8] );
     NeighborhoodType hood;


### PR DESCRIPTION
ITK standards are for each parameter or ivar to have a separate set
method. The exists methods which set a min/max pair now call the
standard macro based set methods.