### PR TITLE
ENH: Add template parameter to specify the mask image type

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -82,7 +82,8 @@ namespace Statistics
  **/
 
 template< typename TInputImage,
-          typename TOutputImage>
+          typename TOutputImage,
+          typename TMaskImage = TInputImage>
 class ITK_TEMPLATE_EXPORT CoocurrenceTextureFeaturesImageFilter:public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
@@ -100,7 +101,7 @@ public:
 
   typedef TInputImage                     InputImageType;
   typedef TOutputImage                    OutputImageType;
-  typedef TInputImage                     MaskImageType;
+  typedef TMaskImage                      MaskImageType;
   typedef TInputImage                     DigitizedImageType;
 
   typedef typename InputImageType::PixelType    PixelType;
@@ -128,10 +129,10 @@ public:
   itkGetConstMacro(NeighborhoodRadius, NeighborhoodRadiusType);
 
   /** Method to set the mask image */
-  itkSetInputMacro(MaskImage, InputImageType);
+  itkSetInputMacro(MaskImage, MaskImageType);
 
   /** Method to get the mask image */
-  itkGetInputMacro(MaskImage, InputImageType);
+  itkGetInputMacro(MaskImage, MaskImageType);
 
 
   /** Specify the default number of bins per axis */
@@ -182,8 +183,8 @@ public:
    * Set the pixel value of the mask that should be considered "inside" the
    * object. Defaults to 1.
    */
-  itkSetMacro( InsidePixelValue, PixelType );
-  itkGetConstMacro( InsidePixelValue, PixelType );
+  itkSetMacro( InsidePixelValue, MaskPixelType );
+  itkGetConstMacro( InsidePixelValue, MaskPixelType );
 
   /** Set the calculator to normalize the histogram (divide all bins by the
     total frequency). Normalization is off by default. */
@@ -234,7 +235,7 @@ private:
   unsigned int                      m_NumberOfBinsPerAxis;
   PixelType                         m_HistogramMinimum;
   PixelType                         m_HistogramMaximum;
-  PixelType                         m_InsidePixelValue;
+  MaskPixelType                     m_InsidePixelValue;
   bool                              m_Normalize;
 
 

--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -83,8 +83,9 @@ namespace Statistics
 
 template< typename TInputImage,
           typename TOutputImage,
-          typename TMaskImage = TInputImage>
-class ITK_TEMPLATE_EXPORT CoocurrenceTextureFeaturesImageFilter:public ImageToImageFilter< TInputImage, TOutputImage >
+          typename TMaskImage = Image< unsigned char, TInputImage::ImageDimension> >
+class ITK_TEMPLATE_EXPORT CoocurrenceTextureFeaturesImageFilter
+  : public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
   /** Standard typedefs */

--- a/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
@@ -28,13 +28,13 @@ namespace itk
 {
 namespace Statistics
 {
-template< typename TInputImage, typename TOutputImage>
-CoocurrenceTextureFeaturesImageFilter< TInputImage, TOutputImage >
+template< typename TInputImage, typename TOutputImage, typename TMaskImage>
+CoocurrenceTextureFeaturesImageFilter< TInputImage, TOutputImage, TMaskImage>
 ::CoocurrenceTextureFeaturesImageFilter() :
     m_NumberOfBinsPerAxis( itkGetStaticConstMacro( DefaultBinsPerAxis ) ),
     m_HistogramMinimum( NumericTraits<PixelType>::NonpositiveMin() ),
     m_HistogramMaximum( NumericTraits<PixelType>::max() ),
-    m_InsidePixelValue( NumericTraits<PixelType>::OneValue() )
+    m_InsidePixelValue( NumericTraits<MaskPixelType>::OneValue() )
 {
   this->SetNumberOfRequiredInputs( 1 );
   this->SetNumberOfRequiredOutputs( 1 );
@@ -70,9 +70,9 @@ CoocurrenceTextureFeaturesImageFilter< TInputImage, TOutputImage >
   this->m_Normalize = false;
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::SetOffset( const OffsetType offset )
 {
   OffsetVectorPointer offsetVector = OffsetVector::New();
@@ -80,9 +80,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   this->SetOffsets( offsetVector );
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::BeforeThreadedGenerateData()
 {
 
@@ -100,8 +100,8 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   typename FilterType::Pointer filter = FilterType::New();
   if (this->GetMaskImage() != ITK_NULLPTR)
     {
-    typename TInputImage::Pointer mask = MaskImageType::New();
-    mask->Graft(const_cast<TInputImage *>(this->GetMaskImage()));
+    typename TMaskImage::Pointer mask = MaskImageType::New();
+    mask->Graft(const_cast<TMaskImage *>(this->GetMaskImage()));
     filter->SetInput1(mask);
     }
   else
@@ -116,9 +116,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   m_DigitizedInputImage = filter->GetOutput();
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::AfterThreadedGenerateData()
 {
   // Free internal image
@@ -126,9 +126,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
 }
 
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
                        ThreadIdType threadId)
 {
@@ -250,9 +250,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
     }
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::GenerateOutputInformation()
 {
   // Call superclass's version
@@ -269,9 +269,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
     }
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 bool
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::IsInsideNeighborhood(const OffsetType &iteratedOffset)
 {
   bool insideNeighborhood = true;
@@ -287,9 +287,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   return insideNeighborhood;
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::ComputeFeatures( const vnl_matrix<unsigned int> &hist, const unsigned int totalNumberOfFreq,
                    typename TOutputImage::PixelType &outputPixel)
 {
@@ -364,9 +364,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
     outputPixel[7] = haralickCorrelation;
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::ComputeMeansAndVariances(const vnl_matrix<unsigned int> &hist,
                            const unsigned int totalNumberOfFreq,
                            double & pixelMean,
@@ -441,9 +441,9 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
   delete[] marginalSums;
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage>
+CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
 

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -96,7 +96,7 @@ namespace Statistics
 
 template< typename TInputImage,
           typename TOutputImage,
-          typename TMaskImage = TInputImage>
+          typename TMaskImage = Image< unsigned char, TInputImage::ImageDimension> >
 class ITK_TEMPLATE_EXPORT RunLengthTextureFeaturesImageFilter
   : public ImageToImageFilter< TInputImage, TOutputImage >
 {

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -95,8 +95,10 @@ namespace Statistics
  */
 
 template< typename TInputImage,
-          typename TOutputImage>
-class ITK_TEMPLATE_EXPORT RunLengthTextureFeaturesImageFilter:public ImageToImageFilter< TInputImage, TOutputImage >
+          typename TOutputImage,
+          typename TMaskImage = TInputImage>
+class ITK_TEMPLATE_EXPORT RunLengthTextureFeaturesImageFilter
+  : public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
   /** Standard typedefs */
@@ -113,10 +115,11 @@ public:
 
   typedef TInputImage                     InputImageType;
   typedef TOutputImage                    OutputImageType;
-  typedef TInputImage                     MaskImageType;
+  typedef TMaskImage                      MaskImageType;
   typedef TInputImage                     DigitizedImageType;
 
   typedef typename InputImageType::PixelType    PixelType;
+  typedef typename MaskImageType::PixelType     MaskPixelType;
   typedef typename InputImageType::IndexType    IndexType;
   typedef typename InputImageType::PointType    PointType;
 
@@ -140,10 +143,10 @@ public:
   itkGetConstMacro(NeighborhoodRadius, NeighborhoodRadiusType);
 
   /** Method to set the mask image */
-  itkSetInputMacro(MaskImage, InputImageType);
+  itkSetInputMacro(MaskImage, MaskImageType);
 
   /** Method to get the mask image */
-  itkGetInputMacro(MaskImage, InputImageType);
+  itkGetInputMacro(MaskImage, MaskImageType);
 
 
   /** Specify the default number of bins per axis */
@@ -211,8 +214,8 @@ public:
    * Set the pixel value of the mask that should be considered "inside" the
    * object. Defaults to 1.
    */
-  itkSetMacro( InsidePixelValue, PixelType );
-  itkGetConstMacro( InsidePixelValue, PixelType );
+  itkSetMacro( InsidePixelValue, MaskPixelType );
+  itkGetConstMacro( InsidePixelValue, MaskPixelType );
 
   typedef typename OutputImageType::PixelType OutputPixelType;
   typedef typename NumericTraits< OutputPixelType >::ScalarRealType OutputRealType;
@@ -256,7 +259,7 @@ private:
   PixelType                         m_HistogramValueMaximum;
   RealType                          m_HistogramDistanceMinimum;
   RealType                          m_HistogramDistanceMaximum;
-  PixelType                         m_InsidePixelValue;
+  MaskPixelType                     m_InsidePixelValue;
   typename TInputImage::SpacingType m_Spacing;
 };
 } // end of namespace Statistics

--- a/include/itkRunLengthTextureFeaturesImageFilter.hxx
+++ b/include/itkRunLengthTextureFeaturesImageFilter.hxx
@@ -28,15 +28,15 @@ namespace itk
 {
 namespace Statistics
 {
-template< typename TInputImage, typename TOutputImage>
-RunLengthTextureFeaturesImageFilter< TInputImage, TOutputImage >
+template< typename TInputImage, typename TOutputImage, typename TMaskImage>
+RunLengthTextureFeaturesImageFilter< TInputImage, TOutputImage, TMaskImage>
 ::RunLengthTextureFeaturesImageFilter() :
     m_NumberOfBinsPerAxis( itkGetStaticConstMacro( DefaultBinsPerAxis ) ),
     m_HistogramValueMinimum( NumericTraits<PixelType>::NonpositiveMin() ),
     m_HistogramValueMaximum( NumericTraits<PixelType>::max() ),
     m_HistogramDistanceMinimum( NumericTraits<RealType>::ZeroValue() ),
     m_HistogramDistanceMaximum( NumericTraits<RealType>::max() ),
-    m_InsidePixelValue( NumericTraits<PixelType>::OneValue() ),
+    m_InsidePixelValue( NumericTraits<MaskPixelType>::OneValue() ),
     m_Spacing( 1.0 )
 {
   this->SetNumberOfRequiredInputs( 1 );
@@ -71,9 +71,9 @@ RunLengthTextureFeaturesImageFilter< TInputImage, TOutputImage >
   this->m_NeighborhoodRadius = nhood.GetRadius( );
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::SetOffset( const OffsetType offset )
 {
   OffsetVectorPointer offsetVector = OffsetVector::New();
@@ -81,9 +81,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
   this->SetOffsets( offsetVector );
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::BeforeThreadedGenerateData()
 {
 
@@ -101,8 +101,8 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
   typename FilterType::Pointer filter = FilterType::New();
   if (this->GetMaskImage() != ITK_NULLPTR)
     {
-    typename TInputImage::Pointer mask = MaskImageType::New();
-    mask->Graft(const_cast<TInputImage *>(this->GetMaskImage()));
+    typename TMaskImage::Pointer mask = MaskImageType::New();
+    mask->Graft(const_cast<TMaskImage *>(this->GetMaskImage()));
     filter->SetInput1(mask);
     }
   else
@@ -120,9 +120,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 }
 
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
   void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::AfterThreadedGenerateData()
 {
   // free internal image
@@ -130,9 +130,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 }
 
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
                        ThreadIdType threadId)
 {
@@ -295,9 +295,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::GenerateOutputInformation()
 {
   Superclass::GenerateOutputInformation();
@@ -313,9 +313,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
     }
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::NormalizeOffsetDirection(OffsetType &offset)
 {
   itkDebugMacro("old offset = " << offset << std::endl);
@@ -337,9 +337,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
   itkDebugMacro("new  offset = " << offset << std::endl);
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 bool
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::IsInsideNeighborhood(const OffsetType &iteratedOffset)
 {
   bool insideNeighborhood = true;
@@ -355,9 +355,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
   return insideNeighborhood;
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::IncreaseHistogram(vnl_matrix<unsigned int> &histogram, unsigned int &totalNumberOfRuns,
                      const PixelType &currentInNeighborhoodPixelIntensity,
                      const OffsetType &offset, const unsigned int &pixelDistance)
@@ -377,9 +377,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
     }
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::ComputeFeatures( vnl_matrix<unsigned int> &histogram, const unsigned int &totalNumberOfRuns,
                    typename TOutputImage::PixelType &outputPixel)
 {
@@ -464,9 +464,9 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
 
 }
 
-template<typename TInputImage, typename TOutputImage>
+template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
-RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage>
+RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf( os, indent );

--- a/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
@@ -63,7 +63,7 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType, MaskImageType > FilterType;
+    InputImageType, OutputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter,

--- a/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterInstantiationTest.cxx
@@ -38,13 +38,16 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
 
   // Declare types
   typedef int                                         InputPixelType;
+  typedef unsigned char                               MaskPixelType;
   typedef float                                       OutputPixelComponentType;
   typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
                                                       OutputPixelType;
 
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< MaskPixelType, ImageDimension >   MaskImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::ImageFileReader< MaskImageType >         MaskReaderType;
   typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
@@ -55,12 +58,12 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
   reader->SetFileName( argv[1] );
 
   // Create and set up a maskReader
-  ReaderType::Pointer maskReader = ReaderType::New();
+  MaskReaderType::Pointer maskReader = MaskReaderType::New();
   maskReader->SetFileName( argv[2] );
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, MaskImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter,
@@ -90,7 +93,7 @@ int CoocurrenceTextureFeaturesImageFilterInstantiationTest( int argc, char *argv
   filter->SetNeighborhoodRadius( hood.GetRadius() );
   TEST_SET_GET_VALUE( hood.GetRadius(), filter->GetNeighborhoodRadius() );
 
-  FilterType::PixelType insidePixelValue = 0;
+  FilterType::MaskPixelType insidePixelValue = 0;
   filter->SetInsidePixelValue( insidePixelValue );
   TEST_SET_GET_VALUE( insidePixelValue, filter->GetInsidePixelValue() );
 

--- a/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
@@ -60,7 +60,7 @@ int CoocurrenceTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -67,7 +67,7 @@ int CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *a
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -66,7 +66,7 @@ int CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int ar
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -62,7 +62,7 @@ int CoocurrenceTextureFeaturesImageFilterTestWithVectorImage( int argc, char *ar
 
   // Create the filter
   typedef itk::Statistics::CoocurrenceTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType  > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter, CoocurrenceTextureFeaturesImageFilter,

--- a/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
@@ -38,13 +38,16 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
 
   // Declare types
   typedef int                                         InputPixelType;
+  typedef unsigned char                               MaskPixelType;
   typedef float                                       OutputPixelComponentType;
   typedef itk::Vector< OutputPixelComponentType, VectorComponentDimension >
                                                       OutputPixelType;
 
   typedef itk::Image< InputPixelType, ImageDimension >  InputImageType;
+  typedef itk::Image< MaskPixelType, ImageDimension >   MaskImageType;
   typedef itk::Image< OutputPixelType, ImageDimension > OutputImageType;
   typedef itk::ImageFileReader< InputImageType >        ReaderType;
+  typedef itk::ImageFileReader< MaskImageType >         MaskReaderType;
   typedef itk::Neighborhood< InputImageType::PixelType,
     InputImageType::ImageDimension >                    NeighborhoodType;
 
@@ -54,12 +57,12 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
   reader->SetFileName( argv[1] );
 
   // Create and set up a maskReader
-  ReaderType::Pointer maskReader = ReaderType::New();
+  MaskReaderType::Pointer maskReader = MaskReaderType::New();
   maskReader->SetFileName( argv[2] );
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, MaskImageType > FilterType;
 
   FilterType::Pointer filter = FilterType::New();
 
@@ -96,7 +99,7 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
   filter->SetNeighborhoodRadius( hood.GetRadius() );
   TEST_SET_GET_VALUE( hood.GetRadius(), filter->GetNeighborhoodRadius() );
 
-  FilterType::PixelType insidePixelValue = 0;
+  FilterType::MaskPixelType insidePixelValue = 0;
   filter->SetInsidePixelValue( insidePixelValue );
   TEST_SET_GET_VALUE( insidePixelValue, filter->GetInsidePixelValue() );
 

--- a/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterInstantiationTest.cxx
@@ -62,7 +62,7 @@ int RunLengthTextureFeaturesImageFilterInstantiationTest( int argc, char *argv[]
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType, MaskImageType > FilterType;
+    InputImageType, OutputImageType > FilterType;
 
   FilterType::Pointer filter = FilterType::New();
 

--- a/test/RunLengthTextureFeaturesImageFilterTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTest.cxx
@@ -67,7 +67,7 @@ int RunLengthTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
 
   FilterType::Pointer filter = FilterType::New();
 

--- a/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -69,7 +69,7 @@ int RunLengthTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *arg
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );

--- a/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -70,7 +70,7 @@ int RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int argc
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );

--- a/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -64,7 +64,7 @@ int RunLengthTextureFeaturesImageFilterTestWithVectorImage( int argc, char *argv
 
   // Create the filter
   typedef itk::Statistics::RunLengthTextureFeaturesImageFilter<
-    InputImageType, OutputImageType > FilterType;
+    InputImageType, OutputImageType, InputImageType > FilterType;
   FilterType::Pointer filter = FilterType::New();
 
   EXERCISE_BASIC_OBJECT_METHODS( filter, RunLengthTextureFeaturesImageFilter,


### PR DESCRIPTION
Add 3rd template argument to the CoocurrenceTextureFeaturesImageFilter
and the RunLengthTextureFeaturesImageFilter to allow the specification
of the Mask image type. Because the mask image essentially contains
boolean values using an unsigned byte type, maybe more memory
efficient if the primary input image is a larger pixel type. Also it
is sometime a convention to only use unsigned byte pixel for mask
images.