### PR TITLE
BUG: Missing itkMath.h include

### DIFF
--- a/include/itkDigitizerFunctor.h
+++ b/include/itkDigitizerFunctor.h
@@ -19,6 +19,7 @@
 #define itkDigitizerFunctor_h
 
 #include "itkNumericTraits.h"
+#include "itkMath.h"
 
 namespace itk
 {


### PR DESCRIPTION
Without this patch, the following error happens:

include/itkDigitizerFunctor.h:79:16: error: use of undeclared identifier 'Math'
     return Math::Floor< TOutput >((inputPixel - m_Min)/((m_Max-m_Min)/ \
         (float)m_NumberOfBinsPerAxis));