### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkFirstOrderTextureFeaturesImageFilter.h
+++ b/include/itkFirstOrderTextureFeaturesImageFilter.h
@@ -57,6 +57,8 @@ class ITK_TEMPLATE_EXPORT FirstOrderTextureFeaturesImageFilter:
                                                                           typename TOutputImage::PixelType > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FirstOrderTextureFeaturesImageFilter);
+
   /** Standard class type alias. */
   using Self = FirstOrderTextureFeaturesImageFilter;
   using Superclass = MovingHistogramImageFilter< TInputImage, TOutputImage, TKernel,
@@ -112,10 +114,7 @@ protected:
 
 
   ~FirstOrderTextureFeaturesImageFilter() override {}
-private:
-  FirstOrderTextureFeaturesImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);                  //purposely not implemented
-};                                               // end of class
+};
 } // end namespace itk
 
 #endif


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.