### PR TITLE
ENH: Build CI against ITK 4.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build-and-test:
     working_directory: /ITKTextureFeatures-build
     docker:
-      - image: insighttoolkit/module-ci:latest
+      - image: insighttoolkit/module-ci:v4.13
     steps:
       - checkout:
           path: /ITKTextureFeatures
@@ -50,6 +50,7 @@ jobs:
           name: Build Python packages
           no_output_timeout: 1.0h
           command: |
+            export ITK_PACKAGE_VERSION=v4.13.0
             ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
       - store_artifacts:
           path: dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 script:
 - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
+- export ITK_PACKAGE_VERSION=v4.13.0
 - ./macpython-download-cache-and-build-module-wheels.sh
 - tar -zcvf dist.tar.gz dist/
 - curl -F file="@dist.tar.gz" https://filebin.ca/upload.php

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ ITKTextureFeatures
 .. image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKTextureFeatures.svg?style=shield
     :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKTextureFeatures
 
-.. image:: https://travis-ci.org/InsightSoftwareConsortium/ITKTextureFeatures.svg?branch=master
+.. image:: https://travis-ci.org/InsightSoftwareConsortium/ITKTextureFeatures.svg?branch=release
     :target: https://travis-ci.org/InsightSoftwareConsortium/ITKTextureFeatures
 
 .. image:: https://img.shields.io/appveyor/ci/jbvimort/itktexturefeatures.svg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,14 @@
 branches:
  only:
   - master
+  - release
 
 version: "0.0.1.{build}"
 
 install:
 
   - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
-  - ps: .\windows-download-cache-and-build-module-wheels.ps1 
+  - ps: $env:ITK_PACKAGE_VERSION='v4.13.0'; .\windows-download-cache-and-build-module-wheels.ps1
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,6 @@ setup(
     keywords='ITK InsightToolkit glcm texture features image imaging',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk'
+        r'itk<5'
     ]
     )


### PR DESCRIPTION
The default is currently ITK 5.0 alpha. Build against 4.13 so we can publish
Python packages to PyPI.