### PR TITLE
BUG: Use itk::SimpleFilterWatcher instead of itk::FilterWatcher.

### DIFF
--- a/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
+++ b/test/itkFirstOrderTextureFeaturesImageFilterGTest.cxx
@@ -18,7 +18,7 @@
 #include "itkFirstOrderTextureFeaturesImageFilter.h"
 #include "itkFlatStructuringElement.h"
 #include "itkAdditiveGaussianNoiseImageFilter.h"
-#include "itkFilterWatcher.h"
+#include "itkSimpleFilterWatcher.h"
 
 #include "gtest/gtest.h"
 
@@ -77,7 +77,7 @@ TEST(TextureFeatures, FirstOrder_Test1)
   filter->SetKernel( kernel );
   filter->SetInput( noiseFilter->GetOutput() );
 
-  FilterWatcher watcher(filter, "filter");
+  itk::SimpleFilterWatcher watcher(filter, "filter");
 
 
   ImageType::SizeType requestSize = {{10,10}};
@@ -147,7 +147,7 @@ TEST(TextureFeatures, FirstOrder_Test2)
   filter->SetKernel( kernel );
   filter->SetInput( noiseFilter->GetOutput() );
 
-  FilterWatcher watcher(filter, "filter");
+  itk::SimpleFilterWatcher watcher(filter, "filter");
 
 
   ImageType::SizeType requestSize = {{10,10}};


### PR DESCRIPTION
Use `itk::SimpleFilterWatcher` instead of `itk::FilterWatcher`.

The `itk::FilterWatcher` class was removed in favour of
`itk::SimpleFilterWatcher` (and thus, its header file named
`itkFilterWatcher.h` was deleted) in this gerrit topic:
http://review.source.kitware.com/#/c/23415/

This bug was identified thanks to the following gerrit topic:
http://review.source.kitware.com/#/c/23428/