### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -224,8 +224,7 @@ protected:
   /** This method causes the filter to generate its output. */
   void BeforeThreadedGenerateData() override;
   void AfterThreadedGenerateData() override;
-  void ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputRegionType & outputRegionForThread ) override;
   void GenerateOutputInformation() override;
 
 private:

--- a/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.hxx
@@ -128,15 +128,10 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
 CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
-::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
-                       ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputRegionType & outputRegionForThread )
 {
   // Recuperation of the different inputs/outputs
   OutputImageType* outputPtr = this->GetOutput();
-
-  ProgressReporter progress( this,
-                             threadId,
-                             outputRegionForThread.GetNumberOfPixels() );
 
   // Creation of the output pixel type
   typename TOutputImage::PixelType outputPixel;
@@ -181,7 +176,6 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
         {
         outputPixel.Fill(0);
         outputIt.Set(outputPixel);
-        progress.CompletedPixel();
         ++inputNIt;
         ++outputIt;
         continue;
@@ -237,7 +231,6 @@ CoocurrenceTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
       this->ComputeFeatures( hist, totalNumberOfFreq, outputPixel);
       outputIt.Set(outputPixel);
 
-      progress.CompletedPixel();
       ++inputNIt;
       ++outputIt;
       }

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -246,8 +246,7 @@ protected:
   /** This method causes the filter to generate its output. */
   void BeforeThreadedGenerateData() override;
   void AfterThreadedGenerateData() override;
-  void ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
-                                    ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData( const OutputRegionType & outputRegionForThread ) override;
   void GenerateOutputInformation() override;
 
 private:

--- a/include/itkRunLengthTextureFeaturesImageFilter.hxx
+++ b/include/itkRunLengthTextureFeaturesImageFilter.hxx
@@ -132,15 +132,10 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
 template<typename TInputImage, typename TOutputImage, typename TMaskImage>
 void
 RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
-::ThreadedGenerateData(const OutputRegionType & outputRegionForThread,
-                       ThreadIdType threadId)
+::DynamicThreadedGenerateData( const OutputRegionType & outputRegionForThread )
 {
   // Get the inputs/outputs
   TOutputImage * outputPtr = this->GetOutput();
-
-  ProgressReporter progress( this,
-                             threadId,
-                             outputRegionForThread.GetNumberOfPixels() );
 
   // Creation of the output pixel type
   typename TOutputImage::PixelType outputPixel;
@@ -208,7 +203,6 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
         {
         outputPixel.Fill(0);
         outputIt.Set(outputPixel);
-        progress.CompletedPixel();
         ++inputNIt;
         ++outputIt;
         continue;
@@ -285,7 +279,6 @@ RunLengthTextureFeaturesImageFilter<TInputImage, TOutputImage, TMaskImage>
       this->ComputeFeatures( histogram, totalNumberOfRuns, outputPixel);
       outputIt.Set(outputPixel);
 
-      progress.CompletedPixel();
       ++inputNIt;
       ++outputIt;
       }


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The solution adopted in this patch set was based on the discussion in:
http://review.source.kitware.com/#/c/23434/