### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/example/computeGLCMFeatures.cxx
+++ b/example/computeGLCMFeatures.cxx
@@ -41,10 +41,10 @@ int main(int argc, char * argv[])
     FilterType::Pointer filter = FilterType::New();
     filter->SetInput(reader->GetOutput());
     filter->SetMaskImage(maskReader->GetOutput());
-    filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-    filter->SetHistogramMinimum(std::atof(argv[5]));
-    filter->SetHistogramMaximum(std::atof(argv[6]));
-    neighborhood.SetRadius( std::atoi(argv[7]) );
+    filter->SetNumberOfBinsPerAxis(std::stoi(argv[4]));
+    filter->SetHistogramMinimum(std::stod(argv[5]));
+    filter->SetHistogramMaximum(std::stod(argv[6]));
+    neighborhood.SetRadius( std::stoi(argv[7]) );
     filter->SetNeighborhoodRadius(neighborhood.GetRadius());
 
     // Create and setup a writter

--- a/example/computeGLRLMFeatures.cxx
+++ b/example/computeGLRLMFeatures.cxx
@@ -42,12 +42,12 @@ int main(int argc, char * argv[])
     FilterType::Pointer filter = FilterType::New();
     filter->SetInput(reader->GetOutput());
     filter->SetMaskImage(maskReader->GetOutput());
-    filter->SetNumberOfBinsPerAxis(std::atoi(argv[4]));
-    filter->SetHistogramValueMinimum(std::atof(argv[5]));
-    filter->SetHistogramValueMaximum(std::atof(argv[6]));
-    filter->SetHistogramDistanceMinimum(std::atof(argv[7]));
-    filter->SetHistogramDistanceMaximum(std::atof(argv[8]));
-    neighborhood.SetRadius( std::atoi(argv[9]) );
+    filter->SetNumberOfBinsPerAxis(std::stoi(argv[4]));
+    filter->SetHistogramValueMinimum(std::stod(argv[5]));
+    filter->SetHistogramValueMaximum(std::stod(argv[6]));
+    filter->SetHistogramDistanceMinimum(std::stod(argv[7]));
+    filter->SetHistogramDistanceMaximum(std::stod(argv[8]));
+    neighborhood.SetRadius( std::stoi(argv[9]) );
     filter->SetNeighborhoodRadius(neighborhood.GetRadius());
 
     // Create and setup a writter

--- a/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTest.cxx
@@ -67,15 +67,15 @@ int CoocurrenceTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramMinimum( pixelValueMin );
     filter->SetHistogramMaximum( pixelValueMax );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[7] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -74,16 +74,16 @@ int CoocurrenceTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *a
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramMinimum( pixelValueMin );
     filter->SetHistogramMaximum( pixelValueMax );
 
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[7] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -74,15 +74,15 @@ int CoocurrenceTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int ar
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramMinimum( pixelValueMin );
     filter->SetHistogramMaximum( pixelValueMax );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[7] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -74,15 +74,15 @@ int CoocurrenceTextureFeaturesImageFilterTestWithVectorImage( int argc, char *ar
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramMinimum( pixelValueMin );
     filter->SetHistogramMaximum( pixelValueMax );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[7] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[7] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/CoocurrenceTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -66,15 +66,15 @@ int CoocurrenceTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[]
 
   if( argc >= 4 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[3] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[3] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[4] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[4] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[5] );
     filter->SetHistogramMinimum( pixelValueMin );
     filter->SetHistogramMaximum( pixelValueMax );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[6] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[6] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/RunLengthTextureFeaturesImageFilterTest.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTest.cxx
@@ -80,25 +80,25 @@ int RunLengthTextureFeaturesImageFilterTest( int argc, char *argv[] )
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
     TEST_SET_GET_VALUE( numberOfBinsPerAxis, filter->GetNumberOfBinsPerAxis() );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramValueMinimum( pixelValueMin );
     filter->SetHistogramValueMaximum( pixelValueMax );
     TEST_SET_GET_VALUE( pixelValueMin, filter->GetHistogramValueMinimum() );
     TEST_SET_GET_VALUE( pixelValueMax, filter->GetHistogramValueMaximum() );
 
-    FilterType::RealType minDistance = std::atof( argv[7] );
-    FilterType::RealType maxDistance = std::atof( argv[8] );
+    FilterType::RealType minDistance = std::stod( argv[7] );
+    FilterType::RealType maxDistance = std::stod( argv[8] );
     filter->SetHistogramDistanceMinimum( minDistance );
     filter->SetHistogramDistanceMaximum( maxDistance );
     TEST_SET_GET_VALUE( minDistance, filter->GetHistogramDistanceMinimum() );
     TEST_SET_GET_VALUE( maxDistance, filter->GetHistogramDistanceMaximum() );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[9] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestSeparateFeatures.cxx
@@ -76,21 +76,21 @@ int RunLengthTextureFeaturesImageFilterTestSeparateFeatures( int argc, char *arg
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramValueMinimum( pixelValueMin );
     filter->SetHistogramValueMaximum( pixelValueMax );
 
-    FilterType::RealType minDistance = std::atof( argv[7] );
-    FilterType::RealType maxDistance = std::atof( argv[8] );
+    FilterType::RealType minDistance = std::stod( argv[7] );
+    FilterType::RealType maxDistance = std::stod( argv[8] );
     filter->SetHistogramDistanceMinimum( minDistance );
     filter->SetHistogramDistanceMaximum( maxDistance );
 
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[9] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures.cxx
@@ -77,20 +77,20 @@ int RunLengthTextureFeaturesImageFilterTestVectorImageSeparateFeatures( int argc
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramValueMinimum( pixelValueMin );
     filter->SetHistogramValueMaximum( pixelValueMax );
 
-    FilterType::RealType minDistance = std::atof( argv[7] );
-    FilterType::RealType maxDistance = std::atof( argv[8] );
+    FilterType::RealType minDistance = std::stod( argv[7] );
+    FilterType::RealType maxDistance = std::stod( argv[8] );
     filter->SetHistogramDistanceMinimum( minDistance );
     filter->SetHistogramDistanceMaximum( maxDistance );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[9] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithVectorImage.cxx
@@ -76,21 +76,21 @@ int RunLengthTextureFeaturesImageFilterTestWithVectorImage( int argc, char *argv
 
   if( argc >= 5 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[4] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[4] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[5] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[6] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[5] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[6] );
     filter->SetHistogramValueMinimum( pixelValueMin );
     filter->SetHistogramValueMaximum( pixelValueMax );
 
 
-    FilterType::RealType minDistance = std::atof( argv[7] );
-    FilterType::RealType maxDistance = std::atof( argv[8] );
+    FilterType::RealType minDistance = std::stod( argv[7] );
+    FilterType::RealType maxDistance = std::stod( argv[8] );
     filter->SetHistogramDistanceMinimum( minDistance );
     filter->SetHistogramDistanceMaximum( maxDistance );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[9] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[9] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );

--- a/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
+++ b/test/RunLengthTextureFeaturesImageFilterTestWithoutMask.cxx
@@ -69,20 +69,20 @@ int RunLengthTextureFeaturesImageFilterTestWithoutMask( int argc, char *argv[] )
 
   if( argc >= 4 )
     {
-    unsigned int numberOfBinsPerAxis = std::atoi( argv[3] );
+    unsigned int numberOfBinsPerAxis = std::stoi( argv[3] );
     filter->SetNumberOfBinsPerAxis( numberOfBinsPerAxis );
 
-    FilterType::PixelType pixelValueMin = std::atof( argv[4] );
-    FilterType::PixelType pixelValueMax = std::atof( argv[5] );
+    FilterType::PixelType pixelValueMin = std::stod( argv[4] );
+    FilterType::PixelType pixelValueMax = std::stod( argv[5] );
     filter->SetHistogramValueMinimum( pixelValueMin );
     filter->SetHistogramValueMaximum( pixelValueMax );
 
-    FilterType::RealType minDistance = std::atof( argv[6] );
-    FilterType::RealType maxDistance = std::atof( argv[7] );
+    FilterType::RealType minDistance = std::stod( argv[6] );
+    FilterType::RealType maxDistance = std::stod( argv[7] );
     filter->SetHistogramDistanceMinimum( minDistance );
     filter->SetHistogramDistanceMaximum( maxDistance );
 
-    NeighborhoodType::SizeValueType neighborhoodRadius = std::atoi( argv[8] );
+    NeighborhoodType::SizeValueType neighborhoodRadius = std::stoi( argv[8] );
     NeighborhoodType hood;
     hood.SetRadius( neighborhoodRadius );
     filter->SetNeighborhoodRadius( hood.GetRadius() );


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/