### PR TITLE
BUG: Avoid histogram range overflow

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -73,6 +73,13 @@ namespace Statistics
  *    intensity range. For example they could be the minimum and maximum intensity of the image, or 0 and
  *    the maximum intensity (if the negative values are considered as noise).
  *
+ * WARNING: This probably won't work for pixels of double or long-double type
+ * unless you set the histogram min and max manually. This is because the largest
+ * histogram bin by default has max value of the largest possible pixel value
+ * plus 1. For double and long-double types, whose "RealType" as defined by the
+ * NumericTraits class is the same, and thus cannot hold any larger values,
+ * this would cause a float overflow.
+ *
  * \sa HistogramToTextureFeaturesFilter
  * \sa ScalarImageToCooccurrenceMatrixFilte
  * \sa ScalarImageToTextureFeaturesFilter

--- a/include/itkDigitizerFunctor.h
+++ b/include/itkDigitizerFunctor.h
@@ -85,8 +85,8 @@ public:
 
   MaskPixelType m_MaskValue; 
 
-  PixelType m_Min;
-  PixelType m_Max;
+  typename NumericTraits<PixelType>::RealType m_Min;
+  typename NumericTraits<PixelType>::RealType m_Max;
 };
 
 }

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -86,6 +86,13 @@ namespace Statistics
  * -# Distance range: For better results the distance range should be adapted to the spacing of the input image
  *    and the size of the neighborhood.
  *
+ * WARNING: This probably won't work for pixels of double or long-double type
+ * unless you set the histogram min and max manually. This is because the largest
+ * histogram bin by default has max value of the largest possible pixel value
+ * plus 1. For double and long-double types, whose "RealType" as defined by the
+ * NumericTraits class is the same, and thus cannot hold any larger values,
+ * this would cause a float overflow.
+ *
  * \sa ScalarImageToRunLengthFeaturesFilter
  * \sa ScalarImageToRunLengthMatrixFilter
  * \sa HistogramToRunLengthFeaturesFilter


### PR DESCRIPTION
Fixes #71.

I didn't implement any automatic range computation because the description already mentions it. I went with the least intrusive changes.

I also copied the warning from [`ScalarImageToCooccurrenceMatrix`](https://itk.org/Doxygen/html/classitk_1_1Statistics_1_1ScalarImageToCooccurrenceMatrixFilter.html) for a potential overflow.