### PR TITLE
COMP: Match CMake minimum required version to ITK's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(TextureFeatures)
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK 4.10 REQUIRED)


### PR DESCRIPTION
Match CMake minimum required version to  ITK's.

Fixes:
```
CMake Warning at D:/a/ITKTextureFeatures/ITK/CMake/ITKModuleExternal.cmake:12 (message):
-- cmake_minimum_required of 3.10.2 is not enough.
  cmake_minimum_required must be at least 3.16.3
Call Stack (most recent call first):
  CMakeLists.txt:8 (include)

-- This is needed to allow proper setting of CMAKE_MSVC_RUNTIME_LIBRARY.
-- Do not be surprised if you run into link errors of the style:
  LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_Static' doesn't match value 'MDd_Dynamic' in module.obj
  cmake_minimum_required must be at least 3.16.3
Call Stack (most recent call first):
  CMakeLists.txt:21 (include)
```

raised for example at:
https://open.cdash.org/build/8374782/configure