### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkCoocurrenceTextureFeaturesImageFilter.h
+++ b/include/itkCoocurrenceTextureFeaturesImageFilter.h
@@ -102,7 +102,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CoocurrenceTextureFeaturesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(CoocurrenceTextureFeaturesImageFilter);
 
   /** standard New() method support */
   itkNewMacro(Self);

--- a/include/itkFirstOrderTextureFeaturesImageFilter.h
+++ b/include/itkFirstOrderTextureFeaturesImageFilter.h
@@ -73,7 +73,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(FirstOrderTextureFeaturesImageFilter, MovingHistogramMorphologyImageFilter);
+  itkOverrideGetNameOfClassMacro(FirstOrderTextureFeaturesImageFilter);
 
   /** Image related type alias. */
   using InputImageType = TInputImage;

--- a/include/itkRunLengthTextureFeaturesImageFilter.h
+++ b/include/itkRunLengthTextureFeaturesImageFilter.h
@@ -115,7 +115,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RunLengthTextureFeaturesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(RunLengthTextureFeaturesImageFilter);
 
   /** standard New() method support */
   itkNewMacro(Self);


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
